### PR TITLE
✨ feat : 공통 응답 객체 기능 및 에러 코드 구현

### DIFF
--- a/src/main/java/com/seeat/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/seeat/server/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,75 @@
 package com.seeat.server.global.exception;
 
-//@RestControllerAdvice
+import com.seeat.server.global.response.ApiResponse;
+import com.seeat.server.global.response.CustomException;
+import com.seeat.server.global.response.ErrorCode;
+import com.seeat.server.global.response.FieldErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import java.util.List;
+
+@Slf4j
+@RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    /// 공통 처리 메서드
+    private ApiResponse<CustomException> handleCustomException(CustomException customException) {
+
+        return ApiResponse.fail(customException);
+    }
+
+    /// 예외 처리
+    // 최하위 예외처리
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(Exception.class)
+    public ApiResponse<CustomException> handleException(Exception e) {
+
+        /// 로그 발생
+        log.error(e.getMessage(), e);
+
+        /// 500 예외 코드 검색
+        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+
+        /// 해당 예외 코드로 예외 처리
+        CustomException exception = new CustomException(errorCode, null);
+
+        return handleCustomException(exception);
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler({
+            IllegalStateException.class, IllegalArgumentException.class})
+    public ApiResponse<CustomException> handleIllegalStateException(Exception e) {
+
+        /// 메세지 바탕으로 예외 코드 검색
+        ErrorCode errorCode = ErrorCode.fromMessage(e.getMessage());
+
+        /// 해당 예외 코드로 예외 처리
+        CustomException exception = new CustomException(errorCode, null);
+
+        return handleCustomException(exception);
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ApiResponse<CustomException> handleValidationExceptions(MethodArgumentNotValidException e) {
+
+        /// 파라미터용 예외 코드
+        ErrorCode errorCode = ErrorCode.BAD_PARAMETER;
+
+        /// BindingResult 바탕으로 필드에러 List 생성
+        List<FieldErrorResponse> errors = e.getBindingResult().getFieldErrors()
+                .stream()
+                .map(error -> FieldErrorResponse.of(error.getField(), error.getDefaultMessage()))
+                .toList();
+
+        CustomException exception = new CustomException(errorCode, errors);
+
+        return handleCustomException(exception);
+    }
+
 }

--- a/src/main/java/com/seeat/server/global/response/ApiResponse.java
+++ b/src/main/java/com/seeat/server/global/response/ApiResponse.java
@@ -1,0 +1,38 @@
+package com.seeat.server.global.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.micrometer.common.lang.Nullable;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+
+/**
+ * API 응답을 표준화하기 위한 레코드 클래스입니다.
+ */
+
+public record ApiResponse<T>(
+        @JsonIgnore
+        HttpStatus httpStatus,
+        boolean success,
+        Integer code,
+        String message,
+        @Nullable T data,
+        @Nullable List<FieldErrorResponse> error
+) {
+
+    // 성공 응답 생성 (200 OK)
+    public static <T> ApiResponse<T> ok(@Nullable final T data) {
+        return new ApiResponse<>(HttpStatus.OK, true, HttpStatus.OK.value(), "호출이 성공적으로 완료되었습니다.", data, null);
+    }
+
+    // 생성 성공 응답 (201 Created)
+    public static <T> ApiResponse<T> created() {
+        return new ApiResponse<>(HttpStatus.CREATED, true, HttpStatus.CREATED.value(), "성공적으로 생성되었습니다.", null, null);
+    }
+
+    // 실패 응답 생성
+    public static <T> ApiResponse<T> fail(final CustomException e) {
+        return new ApiResponse<>(e.getErrorCode().getHttpStatus(), false, e.getErrorCode().getCode(), e.getErrorCode().getMessage(), null, e.getFieldErrorResponses());
+    }
+
+}

--- a/src/main/java/com/seeat/server/global/response/CustomException.java
+++ b/src/main/java/com/seeat/server/global/response/CustomException.java
@@ -1,0 +1,22 @@
+package com.seeat.server.global.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import java.util.List;
+
+
+/**
+ * 응답을 하는 커스텀 예외 클래스입니다.
+ * ErrorCode와 필드별 에러 정보를 함께 담아, 일관된 에러 응답을 제공합니다.
+ */
+
+@Getter
+@RequiredArgsConstructor
+public class CustomException extends RuntimeException{
+
+    private final ErrorCode errorCode;
+
+    private final List<FieldErrorResponse> fieldErrorResponses;
+
+
+}

--- a/src/main/java/com/seeat/server/global/response/ErrorCode.java
+++ b/src/main/java/com/seeat/server/global/response/ErrorCode.java
@@ -1,0 +1,113 @@
+package com.seeat.server.global.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 애플리케이션 전역에서 사용하는 에러 코드 Enum입니다.
+ * 각 에러는 고유 코드, HTTP 상태, 메시지를 포함합니다.
+ *
+ * 0~999 : 공통 에러
+ * 1000~1999 : 유저 관련 에러
+ * 2000~2999 : 영화관 관련 에러
+ * 3000~3999 : 리뷰 관련 에러
+ * 10000 이상 : 기타 파라미터 등
+ */
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+
+    // ========================
+    // 0~1000 : 공통 및 보안 에러
+    // ========================
+
+    /** 테스트용 에러 */
+    TEST_ERROR(100, HttpStatus.BAD_REQUEST, "테스트 에러입니다."),
+
+    // 400 Bad Request
+    BAD_REQUEST(400_000, HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    INVALID_FILE_FORMAT(400_001, HttpStatus.BAD_REQUEST, "업로드된 파일 형식이 올바르지 않습니다."),
+    INVALID_INPUT(400_002, HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다."),
+    NULL_VALUE(400_003, HttpStatus.BAD_REQUEST, "Null 값이 들어왔습니다."),
+
+    // 401 Unauthorized
+    TOKEN_EXPIRED(401_000, HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
+    TOKEN_INVALID(401_001, HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    TOKEN_NOT_FOUND(401_002, HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다."),
+    TOKEN_UNSUPPORTED(401_003, HttpStatus.UNAUTHORIZED, "지원하지 않는 토큰 형식입니다."),
+    INVALID_CREDENTIALS(401_004, HttpStatus.UNAUTHORIZED, "인증 정보가 올바르지 않습니다."),
+    INVALID_REFRESH_TOKEN(401_005, HttpStatus.UNAUTHORIZED, "재발급 토큰이 유효하지 않습니다."),
+    INVALID_ACCESS_TOKEN(401_006, HttpStatus.UNAUTHORIZED, "접근 토큰이 유효하지 않습니다."),
+    INVALID_TOKEN(401_007, HttpStatus.UNAUTHORIZED, "토큰이 생성되지 않았습니다."),
+    INVALID_LOGIN(401_008, HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
+    REFRESH_TOKEN_NOT_FOUND(401_011, HttpStatus.UNAUTHORIZED, "저장된 리프레시 토큰이 존재하지 않습니다."),
+    REFRESH_TOKEN_MISMATCH(401_009, HttpStatus.UNAUTHORIZED, "저장된 리프레시 토큰과 일치하지 않습니다."),
+    EXPIRED_REFRESH_TOKEN(401_010, HttpStatus.UNAUTHORIZED, "리프레시 토큰이 만료되었습니다."),
+
+
+    // 403 Forbidden
+    FORBIDDEN(403_000, HttpStatus.FORBIDDEN, "접속 권한이 없습니다."),
+    ACCESS_DENY(403_001, HttpStatus.FORBIDDEN, "접근이 거부되었습니다."),
+
+    /** 엔드포인트 없음  */
+    NOT_FOUND_END_POINT(404, HttpStatus.NOT_FOUND, "요청한 엔드포인트가 존재하지 않습니다."),
+
+    /** 서버 내부 오류  */
+    INTERNAL_SERVER_ERROR(500, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+
+    /** 요청 파라미터 오류 */
+    BAD_PARAMETER(999, HttpStatus.BAD_REQUEST, "요청 파라미터에 문제가 존재합니다."),
+
+    // ========================
+    // 1000~1999 : 유저 관련 응답 에러
+    // ========================
+
+    /** 유저 없음 */
+    NOT_USER(1000, HttpStatus.NOT_FOUND, "해당하는 유저가 존재하지 않습니다."),
+
+    /** 최초 로그인 추가 정보 필요 */
+    FIRST_LOGIN(1200, HttpStatus.NOT_FOUND, "최초 로그인유저이기에 추가정보기입이 필요합니다.");
+
+    // ========================
+    // 2000~2999 : 영화관 관련 에러
+    // ========================
+
+
+
+    // ========================
+    // 3000~3999 : 리뷰 관련 에러
+    // ========================
+
+
+
+
+    /** 에러 코드 (고유값) */
+    private final Integer code;
+
+    /** HTTP 상태 코드 */
+    private final HttpStatus httpStatus;
+
+    /** 에러 메시지 */
+    private final String message;
+
+
+
+    /**
+     * 메시지를 바탕으로 ErrorCode를 반환합니다.
+     * 동일한 메시지가 여러 ErrorCode에 할당된 경우, 첫 번째로 일치하는 ErrorCode를 반환합니다.
+     *
+     * @param message 에러 메시지
+     * @return 일치하는 ErrorCode
+     * @throws IllegalArgumentException 메시지에 해당하는 ErrorCode가 없을 때
+     */
+    public static ErrorCode fromMessage(String message) {
+        for (ErrorCode errorCode : ErrorCode.values()) {
+            if (errorCode.getMessage().equals(message)) {
+                return errorCode;
+            }
+        }
+        throw new IllegalArgumentException("해당 message를 가진 ErrorCode가 존재하지 않습니다: " + message);
+    }
+}

--- a/src/main/java/com/seeat/server/global/response/FieldErrorResponse.java
+++ b/src/main/java/com/seeat/server/global/response/FieldErrorResponse.java
@@ -1,0 +1,16 @@
+package com.seeat.server.global.response;
+
+/**
+ * 파라미터 오류에 대한 예외처리 입니다.
+ * @param field 에러가 발생한 필드명
+ * @param message 해당 필드의 에러 메시지
+ */
+
+public record FieldErrorResponse(
+        String field,
+        String message) {
+
+    public static FieldErrorResponse of(String field, String message) {
+        return new FieldErrorResponse(field, message);
+    }
+}

--- a/src/main/java/com/seeat/server/global/response/pageable/PageRequest.java
+++ b/src/main/java/com/seeat/server/global/response/pageable/PageRequest.java
@@ -1,0 +1,21 @@
+package com.seeat.server.global.response.pageable;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.slf4j.Slf4j;
+
+@Data
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+@Slf4j
+public class PageRequest {
+    @Builder.Default
+    private int page = 1;
+
+    @Builder.Default
+    private int size = 10;
+}

--- a/src/main/java/com/seeat/server/global/response/pageable/PageResponse.java
+++ b/src/main/java/com/seeat/server/global/response/pageable/PageResponse.java
@@ -1,0 +1,57 @@
+package com.seeat.server.global.response.pageable;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Data
+public class PageResponse<E> {
+
+    private List<E> dtoList;
+
+    private List<Integer> pageNumList;
+
+    private PageRequest pageRequest;
+
+    private boolean prev, next;
+
+    private int totalCount, prevPage, nextPage, totalPage, current;
+
+    @Builder(builderMethodName = "withAll")
+    public PageResponse(List<E> dtoList, PageRequest pageRequest, long total) {
+
+        this.dtoList = dtoList;
+        this.pageRequest = pageRequest;
+        this.totalCount = (int)total;
+
+        int end =   (int)(Math.ceil( pageRequest.getPage() / 10.0 )) *  10;
+
+        int start = end - 9;
+
+        int last =  (int)(Math.ceil((totalCount/(double) pageRequest.getSize())));
+
+        end =  end > last ? last: end;
+
+        this.prev = start > 1;
+        this.next =  totalCount > end * pageRequest.getSize();
+
+        this.pageNumList = IntStream.rangeClosed(start,end).boxed().collect(Collectors.toList());
+
+        if(prev) {
+            this.prevPage = start -1;
+        }
+
+        if(next) {
+            this.nextPage = end + 1;
+        }
+
+        this.totalPage = this.pageNumList.size();
+
+        this.current = pageRequest.getPage();
+
+    }
+}
+


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
공통 API 응답 객체(ApiResponse) 구현
- 성공/실패 응답, 제네릭 타입 지원
- 정적 팩토리 메서드(ok, created, fail) 제공

에러 코드 Enum(ErrorCode) 및 커스텀 예외(CustomException) 구현
- 비즈니스 에러 코드 및 메시지 관리
- 필드별 에러 응답(FieldErrorResponse) 구조화

글로벌 예외 처리기에서 일관된 에러 응답 반환
@Valid 기반 파라미터 검증 및 필드별 에러 응답 처리

## 🔍 참고 사항
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->
추가로 확장할 에러 타입이나 응답 구조가 있으면 의견 부탁드립니다!

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->
### 조회 성공 1번 케이스
<img width="1085" alt="200-1" src="https://github.com/user-attachments/assets/a5cda63c-dc90-4e2c-aca8-3bf49d1ae8ef" />

### 조회 성공 2번 케이스
<img width="1085" alt="200-2" src="https://github.com/user-attachments/assets/0de00c62-5a04-4918-b04e-b6382bde59aa" />

### 생성 케이스
<img width="1085" alt="201" src="https://github.com/user-attachments/assets/e62d6cb7-49e8-4fe3-b94e-45d33fe144a5" />

### 실패 케이스
<img width="1085" alt="500" src="https://github.com/user-attachments/assets/cf5c52ec-b76b-4140-b410-24b364b2531b" />

### 파라미터 에러 1번 케이스
<img width="1085" alt="400-1" src="https://github.com/user-attachments/assets/583fc650-66f8-4f42-a943-6b5c0e15c32f" />

### 파라미터 에러 2번 케이스
<img width="1085" alt="400-2" src="https://github.com/user-attachments/assets/1942e302-fa28-41d4-90ab-fc9d363c8f83" />


## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->
#7 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인
