### PR TITLE
✨ feat : Jacoco/CORS/Swagger/Security Config 설정 수정

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -112,7 +112,19 @@ jobs:
       - name: Build with Gradle Wrapper
         run: ./gradlew clean build
 
-      # 3. JUnit 테스트 결과 게시
+      # 3. 테스트 커버리지
+      - name: Test Coverage Report
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.2
+        with:
+          title: Test Coverage Report
+          paths: ${{ github.workspace }}/build/jacoco/index.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-changed-files: 0
+          min-coverage-overall: 0
+          debug-mode: true
+
+      # 4. JUnit 테스트 결과 게시
       - name: Test 결과 출력
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()

--- a/.github/workflows/dev-ci-cd.yml
+++ b/.github/workflows/dev-ci-cd.yml
@@ -106,6 +106,18 @@ jobs:
       - name: Gradle 빌드
         run: ./gradlew clean build
 
+      # 5 . 커버리지
+      - name: Test Coverage Report
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.2
+        with:
+          title: Test Coverage Report
+          paths: ${{ github.workspace }}/build/jacoco/index.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-changed-files: 0
+          min-coverage-overall: 0
+          debug-mode: true
+
       # 5. JUnit 테스트 결과 게시
       - name: Test 결과 출력
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.5.3'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'jacoco'
 }
 
 group = 'com.seeat'
@@ -10,6 +11,87 @@ version = '0.0.1-SNAPSHOT'
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+
+jacoco {
+    toolVersion = "0.8.9"
+}
+
+test {
+    finalizedBy jacocoTestReport
+}
+
+
+jacocoTestReport {
+    dependsOn test
+
+    reports {
+        xml.required = true
+        csv.required = false
+        html.required = true
+
+        xml.destination file("${buildDir}/jacoco/index.xml")
+        html.destination file("${buildDir}/jacoco/index.html")
+    }
+
+    def Qdomains = []
+    for (qPattern in '**/QA'..'**/QZ') { // qPattern = '**/QA', '**/QB', ... '*.QZ'
+        Qdomains.add(qPattern + '*')
+    }
+    afterEvaluate {
+
+        classDirectories.setFrom(
+                files(classDirectories.files.collect {
+                    fileTree(dir: it, exclude: [
+                            "com/seeat/server/global/**",
+                            "**/*Dto*",
+                            "**/*Request*",
+                            "**/*Response*",
+                            "**/*Application*",
+                            "**/*Exception*"
+                    ])
+                })
+        )
+    }
+    finalizedBy 'jacocoTestCoverageVerification'
+}
+
+
+jacocoTestCoverageVerification {
+
+    def Qdomains = []
+    for (qPattern in '*.QA'..'*.QZ') { // qPattern = '*.QA', '*.QB', ... '*.QZ'
+        Qdomains.add(qPattern + '*')
+    }
+
+    violationRules {
+        rule {
+            enabled = true
+            element = 'CLASS'
+
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                //minimum = 0.90
+            }
+
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                //minimum = 0.90
+            }
+            excludes = ["com/seeat/server/global/**",
+                        "**/*Dto*",
+                        "**/*Request*",
+                        "**/*Response*",
+                        "**/*Interceptor*",
+                        "**/*Application*",
+                        "**/*Mapper*",
+                        "**/*Exception*"
+            ] + Qdomains
+        }
     }
 }
 

--- a/src/main/java/com/seeat/server/global/config/LocalSwaggerConfig.java
+++ b/src/main/java/com/seeat/server/global/config/LocalSwaggerConfig.java
@@ -1,7 +1,5 @@
 package com.seeat.server.global.config;
 
-import io.swagger.v3.oas.annotations.OpenAPIDefinition;
-import io.swagger.v3.oas.annotations.servers.Server;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
@@ -12,15 +10,12 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
 /**
- * Swagger / OpenAPI 설정 클래스
- * - HTTPS 설정으로 인해 @OpenAPIDefinition 추가
- * - 스웨거 내부 JWT 설정 추가
+ * Local용 Swagger / OpenAPI 설정 클래스
  */
 
+@Profile("local")
 @Configuration
-@Profile("dev")
-@OpenAPIDefinition(servers = {@Server(url = "https://api.seeat.site", description = "SEEAT 개발 서버")})
-public class SwaggerConfig {
+public class LocalSwaggerConfig {
 
     @Bean
     public OpenAPI openAPI() {

--- a/src/main/java/com/seeat/server/global/config/WebConfig.java
+++ b/src/main/java/com/seeat/server/global/config/WebConfig.java
@@ -1,11 +1,36 @@
 package com.seeat.server.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
 /**
  * 웹 전역 설정 클래스
- *
  * Spring MVC 전반에 걸친 공통 설정을 담당하며,
  * CORS 설정, 인터셉터 등록, 리소스 핸들링 등을 구성한다.
  */
 
-public class WebConfig {
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${cors.front.local}")
+    private String front_local;
+
+    @Value("${cors.front.dev}")
+    private String front_dev;
+
+    /**
+     * CORS 설정을 진행합니다.
+     * @param registry Cors 등록을 위한 파라미터 입니다.
+     */
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins(front_local, front_dev)
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowCredentials(true)
+                .maxAge(3600);
+    }
 }

--- a/src/main/java/com/seeat/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/seeat/server/global/exception/GlobalExceptionHandler.java
@@ -4,14 +4,24 @@ import com.seeat.server.global.response.ApiResponse;
 import com.seeat.server.global.response.CustomException;
 import com.seeat.server.global.response.ErrorCode;
 import com.seeat.server.global.response.FieldErrorResponse;
+import io.swagger.v3.oas.annotations.Hidden;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import java.util.List;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
+import java.util.List;
+import java.util.NoSuchElementException;
+
+/**
+ * 전역 예외 처리 핸들러
+ * - @Hidden 은 스웨거에서 인식 되지 않도록 에러 수정용
+ */
+
+@Hidden
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -44,6 +54,19 @@ public class GlobalExceptionHandler {
     @ExceptionHandler({
             IllegalStateException.class, IllegalArgumentException.class})
     public ApiResponse<CustomException> handleIllegalStateException(Exception e) {
+
+        /// 메세지 바탕으로 예외 코드 검색
+        ErrorCode errorCode = ErrorCode.fromMessage(e.getMessage());
+
+        /// 해당 예외 코드로 예외 처리
+        CustomException exception = new CustomException(errorCode, null);
+
+        return handleCustomException(exception);
+    }
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler({NoSuchElementException.class, NoResourceFoundException.class})
+    public ApiResponse<CustomException> handleNoSuchException(Exception e) {
 
         /// 메세지 바탕으로 예외 코드 검색
         ErrorCode errorCode = ErrorCode.fromMessage(e.getMessage());

--- a/src/main/java/com/seeat/server/global/response/pageable/PageRequest.java
+++ b/src/main/java/com/seeat/server/global/response/pageable/PageRequest.java
@@ -1,11 +1,18 @@
 package com.seeat.server.global.response.pageable;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * 페이지네이션을 위한 요청 클래스
+ * - @Schema 를 통해 스웨거에서 기본적으로 값을 지정해두었습니다.
+ */
 
 @Data
 @SuperBuilder
@@ -14,8 +21,10 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class PageRequest {
     @Builder.Default
+    @Schema(example = "1")
     private int page = 1;
 
     @Builder.Default
+    @Schema(example = "10")
     private int size = 10;
 }

--- a/src/main/java/com/seeat/server/security/config/SecurityConfig.java
+++ b/src/main/java/com/seeat/server/security/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -23,14 +24,19 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
     private final CustomOAuth2UserService customOAuth2UserService;
     private final CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
-
     private final JwtFilter jwtFilter;
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/", "/login/**", "/oauth2/**", "/api/v1/users").permitAll()
+                        .requestMatchers(
+                                "/",
+                                "/login/**",
+                                "/oauth2/**",
+                                "/api/v1/users"
+                        ).permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2
@@ -46,4 +52,22 @@ public class SecurityConfig {
 
         return http.build();
     }
+
+    /**
+     * 스웨거 및 홈화면 필터 ignore
+     */
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return (web) -> web.ignoring().requestMatchers(
+                "/favicon.ico",
+                "/swagger-ui/**",
+                "/v3/api-docs/**",
+                "/swagger-resources/**",
+                "/webjars/**",
+                "/index.html",
+                "**.css",
+                "/home"
+        );
+    }
+
 }


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->

### Swagger(JWT 적용)
Swagger UI에서 JWT 인증 헤더를 입력할 수 있도록 설정을 추가했습니다.
API 문서에서 JWT 토큰을 통한 인증 테스트가 가능합니다.

### 환경별 Swagger 분리
@OpenAPIDefinition을 활용하여 HTTPS 도메인 환경(local, dev 등)에 따라 Swagger 문서가 분리되도록 구성했습니다.
개발/로컬 환경별로 Swagger 접근 및 설정이 다르게 동작합니다.

### CORS 설정 개선
CORS(Cross-Origin Resource Sharing) 정책을 명확하게 설정하여, 프론트엔드의 local/dev 환경에서의 요청도 허용하도록 수정했습니다.
허용 origin, 메서드, 헤더 등 세부 정책을 환경 변수(@Value)로 관리하여 유연성을 높였습니다.

### 환경 변수 적용
프론트엔드의 local 및 dev 도메인을 모두 환경 변수(@Value)로 받아서 CORS 설정에 반영했습니다.
환경별로 별도의 설정 파일이나 프로퍼티를 통해 관리할 수 있습니다.

### Jacoco 적용
Jacoco 커버리지 리포트 및 검증 자동화
Jacoco를 적용하여 테스트 커버리지 리포트가 자동으로 생성되도록 설정했습니다.
DTO, Request, Response, Exception 등 불필요한 클래스는 커버리지 집계에서 제외되며, 커버리지 기준(라인/분기 등)은 필요에 따라 쉽게 조정할 수 있습니다.

### Swagger, 파비콘, 홈화면, 정적 리소스 완전 허용
Swagger, 홈화면, 정적 리소스 등은 인증 없이 누구나 접근 가능합니다.

## 🔍 참고 사항
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->
- Swagger에서 JWT 인증이 필요한 API는 Authorize 버튼을 통해 토큰을 입력해야 정상적으로 테스트할 수 있습니다.
- 노션에서 yml 업데이트 부탁드려요~!

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->
<img width="1492" alt="스크린샷 2025-07-06 21 40 05" src="https://github.com/user-attachments/assets/a5a1a961-4e79-49a7-8ed7-c80f99d05859" />

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->
closed #12, #15

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인
