### PR TITLE
🔥 hotfix : 프론트 헤더 접근 권한 문제 수정

### DIFF
--- a/src/main/java/com/seeat/server/domain/auth/application/dto/response/TokenResponse.java
+++ b/src/main/java/com/seeat/server/domain/auth/application/dto/response/TokenResponse.java
@@ -1,0 +1,11 @@
+package com.seeat.server.domain.auth.application.dto.response;
+
+/**
+ * accessToken 응답입니다.
+ *
+ * @param accessToken accessToken
+ */
+public record TokenResponse(
+        String accessToken
+) {
+}

--- a/src/main/java/com/seeat/server/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/seeat/server/domain/auth/presentation/AuthController.java
@@ -1,0 +1,60 @@
+package com.seeat.server.domain.auth.presentation;
+
+import com.seeat.server.domain.auth.application.dto.response.TokenResponse;
+import com.seeat.server.domain.auth.presentation.swagger.AuthControllerSpec;
+import com.seeat.server.domain.user.domain.entity.User;
+import com.seeat.server.global.response.ApiResponse;
+import com.seeat.server.global.response.CustomException;
+import com.seeat.server.global.response.ErrorCode;
+import com.seeat.server.global.util.JwtConstants;
+import com.seeat.server.security.jwt.service.TokenService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController implements AuthControllerSpec {
+
+    private final TokenService tokenService;
+
+    @GetMapping
+    public ApiResponse<TokenResponse> getAccessToken(HttpServletRequest request){
+
+        // 클라이언트 쿠키에서 refreshToken 추출
+        String refreshToken = extractRefreshTokenFromCookies(request.getCookies());
+
+        // 사용자 정보 조회
+        Optional<User> user = tokenService.getUserFromRefreshToken(refreshToken);
+        if (user.isEmpty()) {
+
+            return ApiResponse.fail(new CustomException(ErrorCode.NOT_USER, null));
+        }
+
+        // 새로운 accessToken 생성
+        String newAccessToken = tokenService.generateAccessToken(user.get());
+
+        // accessToken 응답
+        return ApiResponse.ok(new TokenResponse(newAccessToken));
+    }
+
+    private String extractRefreshTokenFromCookies(Cookie[] cookies) {
+        // 쿠키에서 refreshToken 추출
+        if (cookies == null) return null;
+
+        for (Cookie cookie : cookies) {
+            if (JwtConstants.REFRESH_TOKEN_COOKIE.equals(cookie.getName())) {
+                // 쿠키 값 반환
+                return cookie.getValue();
+            }
+        }
+        // 없으면 null
+        return null;
+    }
+}

--- a/src/main/java/com/seeat/server/domain/auth/presentation/swagger/AuthControllerSpec.java
+++ b/src/main/java/com/seeat/server/domain/auth/presentation/swagger/AuthControllerSpec.java
@@ -1,0 +1,16 @@
+package com.seeat.server.domain.auth.presentation.swagger;
+
+import com.seeat.server.domain.auth.application.dto.response.TokenResponse;
+import com.seeat.server.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Tag(name = "토큰 조회 API", description = "토큰 조회하는 API 입니다.")
+public interface AuthControllerSpec {
+    @Operation(summary = "AccessToken 조회", description = "RefreshToken 기반 AccessToken 재발급")
+    @GetMapping
+    ApiResponse<TokenResponse> getAccessToken(HttpServletRequest request);
+
+}

--- a/src/main/java/com/seeat/server/global/service/RedisService.java
+++ b/src/main/java/com/seeat/server/global/service/RedisService.java
@@ -10,6 +10,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.util.Map;
+import java.util.Set;
+
 /**
  * Redis와의 상호작용을 담당하는 서비스 클래스
  *
@@ -42,6 +44,17 @@ public class RedisService {
             return null;
         }
         return objectMapper.convertValue(value, clazz);
+    }
+
+    public boolean existsRefreshToken(String token) {
+        Set<String> keys = redisTemplate.keys(REFRESH_TOKEN_PREFIX + "*");
+        if (keys == null || keys.isEmpty()) return false;
+
+        ValueOperations<String, Object> values = redisTemplate.opsForValue();
+
+        return keys.stream()
+                .map(values::get)
+                .anyMatch(value -> token.equals(value));
     }
 
     public void deleteValues(String key) {

--- a/src/main/java/com/seeat/server/security/config/CorsConfig.java
+++ b/src/main/java/com/seeat/server/security/config/CorsConfig.java
@@ -35,6 +35,8 @@ public class CorsConfig {
         configuration.addAllowedMethod("*");
         configuration.setAllowCredentials(true);
 
+        configuration.addExposedHeader("Authorization");
+
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;

--- a/src/main/java/com/seeat/server/security/config/RequestMatcherHolder.java
+++ b/src/main/java/com/seeat/server/security/config/RequestMatcherHolder.java
@@ -74,6 +74,9 @@ public class RequestMatcherHolder {
             new RequestInfo(DELETE, "/api/v1/search", null),
             new RequestInfo(GET, "/api/v1/search/**", null),
 
+            // 토큰 조회 관련
+            new RequestInfo(GET, "/api/v1/auth", null),
+
             // static resources
             new RequestInfo(GET, "/docs/**", null),
             new RequestInfo(GET, "/*.ico", null),

--- a/src/main/java/com/seeat/server/security/jwt/service/TokenService.java
+++ b/src/main/java/com/seeat/server/security/jwt/service/TokenService.java
@@ -10,12 +10,14 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Optional;
 
 /**
  * 토큰 발급 서비스
@@ -79,5 +81,24 @@ public class TokenService {
         refreshTokenCookie.setMaxAge((int) (devTokenExpiration / 1000));
 
         response.addCookie(refreshTokenCookie);
+    }
+
+    public Optional<User> getUserFromRefreshToken(String refreshToken) {
+        if (refreshToken == null || !redisService.existsRefreshToken(refreshToken)) {
+            return Optional.empty();
+        }
+
+        if (!jwtProvider.validateToken(refreshToken)) {
+            return Optional.empty();
+        }
+
+        Authentication authentication = jwtProvider.getAuthentication(refreshToken);
+        User user = (User) authentication.getPrincipal();
+
+        return Optional.ofNullable(user);
+    }
+
+    public String generateAccessToken(User user) {
+        return jwtProvider.generateAccessToken(user);
     }
 }


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- CORSconfig에 프론트가 Authorization 헤더 접근 가능하게 수정했습니다.
- 기존 회원의 경우 리다이렉트로 인해 헤더에 토큰이 포함되지 않는 문제가 있어 별도로 accessToken을 조회하는 API를 구현했습니다.

## 🔍 참고 사항
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->
- 헤더 문제는 코드 한줄 추가했습니다.
```
configuration.addExposedHeader("Authorization");
```

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->
<img width="1744" height="581" alt="스크린샷 2025-08-07 040254" src="https://github.com/user-attachments/assets/e0d598c5-8581-4758-92b0-9b29f29a5451" />

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->
#109 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인
